### PR TITLE
Upgrade to test package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 *.js.map
 
 # Include when developing application packages
-pubspec.lock 
+pubspec.lock
 
 # Avoid committing generated JavaScript files
 *.dart.js

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,4 +21,4 @@ dependencies:
   stack_trace: ">=1.2.4 <2.0.0"
   http_server: ">=0.9.5+1 <0.10.0"
 dev_dependencies:
-  unittest: '>=0.11.0+3 <0.12.0'
+  test: '^0.12.3'

--- a/test/server_tests.dart
+++ b/test/server_tests.dart
@@ -4,7 +4,7 @@ import 'dart:convert' as conv;
 import 'dart:async';
 import 'dart:mirrors';
 
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 import 'package:di/di.dart';
 import 'package:redstone/redstone.dart';


### PR DESCRIPTION
This drops the dependency on the old [unittest](https://pub.dartlang.org/packages/unittest) package, and adds a dependency on the newer [test](https://pub.dartlang.org/packages/test) package.

Also removed a trailing space that caused my git to try and add the pubspec.lock file.
