### PR TITLE
Add stacktrace to app.chain

### DIFF
--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -72,6 +72,10 @@ abstract class Chain {
   /// (an interceptor, route, error handler or shelf handler)
   dynamic get error;
 
+  /// Returns the stack trace of the last error thrown by a handler
+  /// (an interceptor, route, error handler or shelf handler)
+  dynamic get stackTrace;
+
   /// Calls the next element of this chain (an interceptor, route or shelf handler)
   Future<shelf.Response> next();
 

--- a/lib/src/router.dart
+++ b/lib/src/router.dart
@@ -357,6 +357,7 @@ class _ChainImpl implements Chain {
   _Target _reqTarget;
 
   Object _error;
+  Object _stackTrace;
 
   bool _errorHandlerExecuted = false;
 
@@ -365,6 +366,9 @@ class _ChainImpl implements Chain {
 
   @override
   dynamic get error => _error;
+
+  @override
+  dynamic get stackTrace => _stackTrace;
 
   @override
   Future<shelf.Response> createResponse(int statusCode,
@@ -471,6 +475,7 @@ class _ChainImpl implements Chain {
     if (!_errorHandlerExecuted) {
       _errorHandlerExecuted = true;
       _error = err;
+      _stackTrace = stack;
       currentContext.lastStackTrace = stack;
       shelf.Response resp = currentContext.response;
       if (err != null || resp.statusCode != statusCode) {


### PR DESCRIPTION
It is really useful sometimes to have access to it.

A possible use case - integration with error aggregators, like Airbrake
or Rollbar, so you could send errors with stacktraces to these services
