### PR TITLE
Add http_parser to dependencies; alphabetize

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,13 +13,14 @@ environment:
 dependencies:
   collection: "^1.2.0"
   crypto: "^0.9.1"
+  di: "^3.3.6"
   grinder: "^0.8.0+1"
-  route_hierarchical: "^0.6.2"
-  shelf: "^0.6.4+3"
   mime: "^0.9.3"
   http: "^0.11.3+3"
-  stack_trace: "^1.5.0"
+  http_parser: '^1.0.0'
   http_server: "^0.9.5+1"
-  di: "^3.3.6"
+  route_hierarchical: "^0.6.2"
+  shelf: "^0.6.4+3"
+  stack_trace: "^1.5.0"
 dev_dependencies:
   test: "^0.12.6+1"


### PR DESCRIPTION
http_parser was actively being used by redstone, but the dependency must have been met transitively:

```
$ git grep http_parser
lib/src/request_mock.dart:import 'package:http_parser/src/media_type.dart';
```
