### PR TITLE
fixes redstone-dart/redstone#133

### DIFF
--- a/lib/src/parameters_processor.dart
+++ b/lib/src/parameters_processor.dart
@@ -176,7 +176,7 @@ Converter getValueConverter(dynamic paramType) {
     return (String value) => num.parse(value);
   }
   if (paramType == boolType) {
-    return (String value) => value.toLowerCase();
+    return (String value) => "true" == value.toLowerCase();
   }
 
   return (String value) => null;


### PR DESCRIPTION
Issue #133 showed an error when declaring QueryParams as bool. While migrating my code from version ^0.5.1 to version ^0.6 I ran into this same issue.

bool QueryParam gives error type 'String is not a subtype of type 'bool' of '<varname>'

It looks like the fix that was suggested and applied got lost along the way.
