### PR TITLE
Clean-up redstone dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.6.6
+Drop package:crypto. Update other package dependencies and fix some strong-mode issues.
+Also fixes definitions of == and hashCode.
+
 ## v0.6.5
 Bug fix: http_body_parser tries to parse body of GET Requests
 

--- a/lib/src/dynamic_map.dart
+++ b/lib/src/dynamic_map.dart
@@ -33,15 +33,16 @@ class DynamicMap<String, V> extends DelegatingMap {
     return null;
   }
 
-  noSuchMethod(Invocation invocation) {
+  dynamic noSuchMethod(Invocation invocation) {
     var key = MirrorSystem.getName(invocation.memberName);
     if (invocation.isGetter) {
       return get(key);
     } else if (invocation.isSetter) {
       this[key.substring(0, key.length - 1)] =
           invocation.positionalArguments.first;
+      return null;
     } else {
-      super.noSuchMethod(invocation);
+      return super.noSuchMethod(invocation);
     }
   }
 }

--- a/lib/src/processor.dart
+++ b/lib/src/processor.dart
@@ -186,7 +186,7 @@ class Processor implements Manager {
   @override
   Iterable<AnnotatedType<MethodMirror>> findMethods(
       ClassMirror clazz, Type annotation) {
-    var methods = [];
+    var methods = <AnnotatedType<MethodMirror>>[];
     clazz.instanceMembers.values.forEach((MethodMirror method) {
       var metadata = method.metadata.firstWhere(
           (m) => m.reflectee.runtimeType == annotation,
@@ -202,7 +202,7 @@ class Processor implements Manager {
 
   @override
   Iterable<AnnotatedType<ClassMirror>> findClasses(Type annotation) {
-    var classes = [];
+    var classes = <AnnotatedType<ClassMirror>>[];
     _findDeclaredClasses().forEach((ClassMirror c) {
       var metadata = c.metadata.firstWhere(
           (m) => m.reflectee.runtimeType == annotation,
@@ -218,7 +218,7 @@ class Processor implements Manager {
 
   @override
   Iterable<AnnotatedType<MethodMirror>> findFunctions(Type annotation) {
-    var functions = [];
+    var functions = <AnnotatedType<MethodMirror>>[];
     _findDeclaredFunctions().forEach((MethodMirror f) {
       var metadata = f.metadata.firstWhere(
           (m) => m.reflectee.runtimeType == annotation,

--- a/lib/src/request_mock.dart
+++ b/lib/src/request_mock.dart
@@ -4,8 +4,6 @@ import 'dart:io';
 import 'dart:convert' as conv;
 import 'dart:async';
 
-import 'package:crypto/crypto.dart';
-
 import 'package:collection/collection.dart' show DelegatingMap;
 import 'package:http/http.dart' as http;
 import 'package:http/src/utils.dart';
@@ -50,7 +48,7 @@ class MockRequest extends RequestParser {
     headers.forEach((k, v) => hValues[k] = [v]);
 
     if (basicAuth != null) {
-      String auth = CryptoUtils.bytesToBase64(
+      String auth = conv.BASE64.encode(
           conv.UTF8.encode("${basicAuth.username}:${basicAuth.password}"));
       hValues[HttpHeaders.AUTHORIZATION] = ["Basic $auth"];
     }

--- a/lib/src/request_parser.dart
+++ b/lib/src/request_parser.dart
@@ -6,7 +6,6 @@ import 'dart:convert' as conv;
 
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:http_server/src/http_body_impl.dart';
-import 'package:crypto/crypto.dart';
 
 import 'constants.dart';
 import 'dynamic_map.dart';
@@ -93,7 +92,7 @@ class RequestParser implements Request {
       List<String> tokens = authorization.split(" ");
       if ("Basic" == tokens[0]) {
         String auth =
-            conv.UTF8.decode(CryptoUtils.base64StringToBytes(tokens[1]));
+            conv.UTF8.decode(conv.BASE64.decode(tokens[1]));
         int idx = auth.indexOf(":");
         if (idx > 0) {
           String username = auth.substring(0, idx);
@@ -195,7 +194,8 @@ class RequestParser implements Request {
   }
 
   void _splitQueryString() {
-    var params = url.query.split("&").fold({}, (map, element) {
+    Map<String,List<String>> params = url.query.split("&").fold({}, (map,
+        element) {
       int index = element.indexOf("=");
       if (index == -1) {
         if (element != "") {

--- a/lib/src/router.dart
+++ b/lib/src/router.dart
@@ -18,7 +18,6 @@ import 'request_parser.dart';
 import 'response_writer.dart';
 import 'dynamic_map.dart';
 import 'logger.dart';
-import 'bootstrap.dart';
 
 const String serverSignature = "dart:io with Redstone.dart/Shelf";
 
@@ -664,7 +663,7 @@ class _ErrorHandlerMapBuilder {
   }
 
   Map<int, List<_ErrorHandler>> build() {
-    var map = {};
+    var map = <int, List<_ErrorHandler>>{};
     errorHandlers.forEach((status, errorHandlerList) {
       map[status] = errorHandlerList
         ..sort((e1, e2) {

--- a/lib/src/scanner.dart
+++ b/lib/src/scanner.dart
@@ -51,7 +51,7 @@ class Scanner {
   }
 
   LibraryMetadata _scanLibrary(LibraryMirror mirror, [Install conf]) {
-    var dependencies = [];
+    var dependencies = <LibraryMetadata>[];
     mirror.libraryDependencies
         .where((d) =>
             d.isImport &&
@@ -145,10 +145,10 @@ class Scanner {
     var metadata =
         mirror.metadata.map((m) => m.reflectee).toList(growable: false);
 
-    var defaultRoutes = [];
-    var routes = [];
-    var interceptors = [];
-    var errorHandlers = [];
+    var defaultRoutes = <DefaultRouteMetadata>[];
+    var routes = <RouteMetadata>[];
+    var interceptors = <InterceptorMetadata>[];
+    var errorHandlers = <ErrorHandlerMetadata>[];
 
     for (DeclarationMirror declaration in mirror.declarations.values) {
       if (declaration is MethodMirror) {

--- a/lib/src/server_metadata.dart
+++ b/lib/src/server_metadata.dart
@@ -58,7 +58,7 @@ class HandlerMetadata<T, M> {
     }
   }
 
-  bool operator ==(HandlerMetadata other) =>
+  bool operator ==(dynamic other) =>
       other is HandlerMetadata && other.id == id;
 
   int get hashCode => id;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: redstone
-version: 0.6.5
+version: 0.6.6
 authors:
   - Luiz Mineo <luiz.mineo@gmail.com>
   - Kenneth Endfinger <kaendfinger@gmail.com>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,15 +12,14 @@ environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
   collection: "^1.2.0"
-  crypto: "^0.9.1"
-  di: "^3.3.6"
+  di: "^3.3.9"
   grinder: "^0.8.0+1"
   mime: "^0.9.3"
   http: "^0.11.3+3"
-  http_parser: '^1.0.0'
+  http_parser: '>=2.2.1 <4.0.0'
   http_server: "^0.9.5+1"
-  route_hierarchical: "^0.6.2"
+  route_hierarchical: "^0.7.0"
   shelf: "^0.6.4+3"
-  stack_trace: "^1.5.0"
+  stack_trace: "^1.6.5"
 dev_dependencies:
   test: "^0.12.6+1"

--- a/test/server_tests.dart
+++ b/test/server_tests.dart
@@ -9,8 +9,8 @@ import 'package:test/test.dart';
 import 'package:di/di.dart';
 import 'package:redstone/redstone.dart';
 import 'package:shelf/shelf.dart' as shelf;
-import 'package:logging/logging.dart';
 
+// These appear to be unused but are dynamically loaded and must be present.
 import 'services/routes.dart' as yo;
 import 'services/type_serialization.dart';
 import 'services/arguments.dart';

--- a/test/services/plugins.dart
+++ b/test/services/plugins.dart
@@ -59,7 +59,7 @@ void toJsonPlugin(Manager manager) {
     if (value == null) {
       return value;
     }
-    return value.toJson();
+    return (value as dynamic).toJson();
   });
 }
 
@@ -179,10 +179,16 @@ class CapturedType {
 
   CapturedType.fromValues(this.typeName, this.metadata);
 
-  bool operator ==(CapturedType other) {
+  bool operator ==(dynamic other) {
     return other is CapturedType &&
         other.typeName == typeName &&
         other.metadata == metadata;
+  }
+
+  int get hashCode {
+    int a = typeName == null ? 0 : typeName.hashCode;
+    int b = metadata == null ? 0 : metadata.hashCode;
+    return (a & 0x1fffffff) + (b & 0x1fffffff);
   }
 
   String toString() => "@$metadata $typeName";


### PR DESCRIPTION
@luizmineo @kaendfinger @austincummings 

These changes remove a dependency to the deprecated crypto package and upgrade the version spec for others to a version that is strong-mode clean. This also begins making redstone clean in strong-mode analysis, but does not try to fix everything. There are still three "errors" that could be corrected by casting, but I'm not sure how that would interact with plugins so I did not include it. A number of warnings remain and some of them look tricky to resolve. Once this is committed I'll take another look at the remaining strong-mode issues.
