### PR TITLE
Scan group hierarchy

### DIFF
--- a/lib/src/scanner.dart
+++ b/lib/src/scanner.dart
@@ -151,7 +151,7 @@ class Scanner {
     var errorHandlers = <ErrorHandlerMetadata>[];
 
     var current = mirror;
-    var visited = [];
+    var visited = <Symbol>[];
     while (current != null) {
       for (DeclarationMirror declaration in current.declarations.values) {
         if (declaration is MethodMirror && !visited.contains(declaration.simpleName)) {


### PR DESCRIPTION
By adding a scan of a group hierarchy, we could override group behavior.

``` dart
abstract class ServicesGroup {
  String name;
  ServicesGroup(this.name);

  @Route("/json", methods: const [POST])
  Map echoJson(@Body(JSON) Map json) {
    json["_name"] = name;
    return json;
  }

  @Route("/form", methods: const [POST])
  Map echoFormAsJson(@Body(FORM) Map form) {
    form["_name"] = name;
    return form;
  }
}

@Group("/one")
class OneServicesGroup extends ServicesGroup {
  OneServicesGroup(): super("one");
}

@Group("/two")
class TwoServicesGroup extends ServicesGroup {
  TwoServicesGroup(): super("two");
}
```

```
Configured target for /two/json [POST]: http_test.ServicesGroup.echoJson (group: http_test.TwoServicesGroup)
Configured target for /two/form [POST]: http_test.ServicesGroup.echoFormAsJson (group: http_test.TwoServicesGroup)
Configured target for /one/json [POST]: http_test.ServicesGroup.echoJson (group: http_test.OneServicesGroup)
Configured target for /one/form [POST]: http_test.ServicesGroup.echoFormAsJson (group: http_test.OneServicesGroup)
```
