### PR TITLE
Fix list support for @app.QueryParam

### DIFF
--- a/lib/src/route_processor.dart
+++ b/lib/src/route_processor.dart
@@ -146,8 +146,10 @@ class RouteProcessor implements Function {
     var name = MirrorSystem.getName(mirror.simpleName);
     var queryParam = (metadata as QueryParam);
     var key = queryParam.name != null ? queryParam.name : name;
-    if (mirror.type == listType) {
-      return (Request req, Converter converter) {
+
+    if (mirror.type.simpleName == listType.simpleName) {
+      var converter = getValueConverter(mirror.type.typeArguments[0]);
+      return (Request req, _) {
         List<String> args = req.queryParameters[key];
         if (args == null) {
           return null;

--- a/test/server_tests.dart
+++ b/test/server_tests.dart
@@ -193,6 +193,35 @@ void main() {
           }));
     });
 
+    test("query parameters with list", () async {
+      var req = new MockRequest("/query_args_with_list",
+          queryParameters: {
+            "arg1": ["a", "b", "c"],
+            "arg2": ["1", "2", "3"],
+            "arg3": ["1.1", "2.2", "3.3"],
+            "arg4": ["1", "2.22", "3.33"],
+            "arg5": ["0", "1", "true"],
+          });
+      var resp = await dispatch(req);
+      expect(
+          conv.JSON.decode(resp.mockContent),
+          equals({
+            "arg1": ["a", "b", "c"],
+            "arg2": [1, 2, 3],
+            "arg3": [1.1, 2.2, 3.3],
+            "arg4": [1, 2.22, 3.33],
+            "arg5": [false, false, true]
+          }));
+    });
+
+    test("path and query parameters", () async {
+      var req = new MockRequest("/path_query_args/arg1",
+          queryParameters: {"arg": "arg2"});
+      var resp = await dispatch(req);
+      expect(conv.JSON.decode(resp.mockContent),
+          equals({"arg": "arg1", "qArg": "arg2"}));
+    });
+
     test("query parameters with num type", () async {
       var req = new MockRequest("/query_args_with_num",
           queryParameters: {"arg1": "1", "arg2": "1.5"});

--- a/test/services/arguments.dart
+++ b/test/services/arguments.dart
@@ -31,6 +31,20 @@ Map queryArgs(@QueryParam("arg1") String arg1, @QueryParam("arg2") int arg2,
       "arg7": arg7
     };
 
+@Route("/query_args_with_list")
+Map queryArgsWithList(@QueryParam("arg1") List<String> arg1,
+    @QueryParam("arg2") List<int> arg2,
+    @QueryParam("arg3") List<double> arg3,
+    @QueryParam("arg4") List<num> arg4,
+    @QueryParam("arg5") List<bool> arg5) =>
+    {
+      "arg1": arg1,
+      "arg2": arg2,
+      "arg3": arg3,
+      "arg4": arg4,
+      "arg5": arg5
+    };
+
 @Route("/query_args_with_num")
 Map queryArgsWithNum(
         @QueryParam("arg1") num arg1, @QueryParam("arg2") num arg2) =>


### PR DESCRIPTION
FIx #53 

``` dart
import 'package:redstone/redstone.dart' as app;

String typeInfo(param) {
  var info = "";
  info += param.runtimeType.toString() + ": ";
  if (param is List) {
    param.forEach((item) {
      info += "\n";
      info += "  " + item.runtimeType.toString() + ": " + item.toString();
    });
  } else {
    info += param.toString();
  }

  return info;
}

@app.Route("/id")
testId(@app.QueryParam("id") int id) {
  return typeInfo(id);
}

@app.Route("/id/int")
testIdsInt(@app.QueryParam("id") List<int> id) {
  return typeInfo(id);
}

@app.Route("/id/string")
testIdsString(@app.QueryParam("id") List<String> id) {
  return typeInfo(id);
}

main() {
  app.setupConsoleLog();
  app.start();
}
```

```
$ curl "http://127.0.0.1:8080/id?id=2&id=3"
int: 2
$ curl "http://127.0.0.1:8080/id/string?id=2&id=3"
List: 
  String: 2
  String: 3
$ curl "http://127.0.0.1:8080/id/int?id=2&id=3"
List: 
  int: 2
  int: 3
```
