### PR TITLE
Fix tests with last Shelf version

### DIFF
--- a/lib/src/http_mock.dart
+++ b/lib/src/http_mock.dart
@@ -13,6 +13,8 @@ class MockHttpHeaders implements HttpHeaders {
 
   ContentType _contentType;
 
+  bool chunkedTransferEncoding;
+
   MockHttpHeaders([Map<String, List<String>> values]) {
     if (values != null) {
       _headers.addAll(values);


### PR DESCRIPTION
With `shelf: ^0.6.6`, tests aren't passing anymore.
